### PR TITLE
Refactor PageState to generic SurveysState

### DIFF
--- a/src/containers/homepage/homepage.container.tsx
+++ b/src/containers/homepage/homepage.container.tsx
@@ -13,7 +13,7 @@ export interface HomepageContainerProps {
 }
 
 const mapStateToProps = (state: AppState): Partial<HomepageContainerProps> => ({
-    surveys: state.surveys.list,
+    surveys: state.surveysState.surveys,
 });
 
 // @ts-ignore

--- a/src/containers/homepage/homepage.container.tsx
+++ b/src/containers/homepage/homepage.container.tsx
@@ -13,7 +13,7 @@ export interface HomepageContainerProps {
 }
 
 const mapStateToProps = (state: AppState): Partial<HomepageContainerProps> => ({
-    surveys: state.homepageState.surveys,
+    surveys: state.surveys.list,
 });
 
 // @ts-ignore

--- a/src/state/index.ts
+++ b/src/state/index.ts
@@ -10,13 +10,13 @@ import { surveysReducer, SurveysState } from './surveys/surveys.reducer';
 
 export interface AppState {
     counterState: CounterState;
-    surveys: SurveysState;
+    surveysState: SurveysState;
     router: RouterState;
 }
 
 export const reducers = (history: History<any>): { [key in keyof AppState]: Reducer<any, any> } => ({
     counterState: counterReducer,
-    surveys: surveysReducer,
+    surveysState: surveysReducer,
     router: connectRouter(history),
 });
 

--- a/src/state/index.ts
+++ b/src/state/index.ts
@@ -5,18 +5,18 @@ import { composeWithDevTools } from 'redux-devtools-extension';
 import { mapStringToEnvironment } from '../common/mappers/environment.mapper';
 import { Environment } from '../common/types/environment.type';
 import { counterReducer, CounterState } from './counter/counter.reducer';
-import { homepageReducer, HomepageState } from './homepage/homepage.reducer';
 import { DEFAULT_STATE } from './state.constants';
+import { surveysReducer, SurveysState } from './surveys/surveys.reducer';
 
 export interface AppState {
     counterState: CounterState;
-    homepageState: HomepageState;
+    surveys: SurveysState;
     router: RouterState;
 }
 
 export const reducers = (history: History<any>): { [key in keyof AppState]: Reducer<any, any> } => ({
     counterState: counterReducer,
-    homepageState: homepageReducer,
+    surveys: surveysReducer,
     router: connectRouter(history),
 });
 

--- a/src/state/state.constants.ts
+++ b/src/state/state.constants.ts
@@ -9,8 +9,8 @@ import { AppState } from './index';
 
 export const DEFAULT_STATE: { [key in Environment]: DeepPartial<AppState> } = {
     [Environment.Production]: {
-        surveys: {
-            list: [
+        surveysState: {
+            surveys: [
                 {
                     key: uuid(), // https://www.npmjs.com/package/uuid
                     name: "Papa John's Innately Interesting Inquiry",
@@ -23,8 +23,8 @@ export const DEFAULT_STATE: { [key in Environment]: DeepPartial<AppState> } = {
         },
     },
     [Environment.Development]: {
-        surveys: {
-            list: [
+        surveysState: {
+            surveys: [
                 {
                     key: uuid(), // https://www.npmjs.com/package/uuid
                     name: "Papa John's Innately Interesting Inquiry",

--- a/src/state/state.constants.ts
+++ b/src/state/state.constants.ts
@@ -1,6 +1,7 @@
 import { DeepPartial } from 'redux';
 import uuid from 'uuid/v4';
 import { Environment } from '../common/types/environment.type';
+import { SurveyStatus } from '../common/types/survey-status.type';
 import { AppState } from './index';
 
 // Define a preloadedState for createStore()
@@ -8,22 +9,22 @@ import { AppState } from './index';
 
 export const DEFAULT_STATE: { [key in Environment]: DeepPartial<AppState> } = {
     [Environment.Production]: {
-        homepageState: {
-            surveys: [
+        surveys: {
+            list: [
                 {
                     key: uuid(), // https://www.npmjs.com/package/uuid
                     name: "Papa John's Innately Interesting Inquiry",
                     createdAt: 1542225329,
                     modifiedAt: 1549233329,
                     questionCount: 11,
-                    status: 'published',
+                    status: SurveyStatus.Published,
                 },
             ],
         },
     },
     [Environment.Development]: {
-        homepageState: {
-            surveys: [
+        surveys: {
+            list: [
                 {
                     key: uuid(), // https://www.npmjs.com/package/uuid
                     name: "Papa John's Innately Interesting Inquiry",

--- a/src/state/surveys/surveys.reducer.ts
+++ b/src/state/surveys/surveys.reducer.ts
@@ -1,13 +1,13 @@
 import { Survey } from '../../common/types/survey.type';
 
 export interface SurveysState {
-    list: Survey[];
+    surveys: Survey[];
 }
 
 // Providing initial state as fallback for failed hydrating from the store
 // See https://redux.js.org/recipes/structuring-reducers/initializing-state
 export const initialSurveysState = {
-    list: [],
+    surveys: [],
 };
 
 export function surveysReducer(state: SurveysState = initialSurveysState): SurveysState {

--- a/src/state/surveys/surveys.reducer.ts
+++ b/src/state/surveys/surveys.reducer.ts
@@ -1,15 +1,15 @@
 import { Survey } from '../../common/types/survey.type';
 
-export interface HomepageState {
-    surveys: Survey[];
+export interface SurveysState {
+    list: Survey[];
 }
 
 // Providing initial state as fallback for failed hydrating from the store
 // See https://redux.js.org/recipes/structuring-reducers/initializing-state
-export const initialHomepageState = {
-    surveys: [],
+export const initialSurveysState = {
+    list: [],
 };
 
-export function homepageReducer(state: HomepageState = initialHomepageState): HomepageState {
+export function surveysReducer(state: SurveysState = initialSurveysState): SurveysState {
     return state;
 }


### PR DESCRIPTION
Is this how it's supposed to be? This way we can better access the same survey array across multiple pages. This also solves a problem in #40, [here](https://github.com/decrn/localsurvey/pull/40/commits/e6a216733ef95c26cf9337e5af5504b25e2a1f4a#diff-88a49c84a4ad1e94760fdc3ea1c705e4) .