### PR TITLE
Create funky StatusTag variations

### DIFF
--- a/src/common/components/status-tag/status-tag.component.tsx
+++ b/src/common/components/status-tag/status-tag.component.tsx
@@ -50,7 +50,7 @@ export class StatusTag extends Component<StatusTagProps> {
             case 'small':
                 return { padding: '0px 6px 10px', fontSize: 10 };
             case 'large':
-                return { padding: '6px 9px 24px', fontSize: 15 };
+                return { padding: '4px 9px 24px', fontSize: 15 };
             default:
             case 'medium':
                 return { padding: '3px 7px 22px', fontSize: 13 };

--- a/src/common/components/status-tag/status-tag.component.tsx
+++ b/src/common/components/status-tag/status-tag.component.tsx
@@ -6,13 +6,19 @@ import { SurveyStatus } from '../../types/survey-status.type';
 export interface StatusTagProps {
     status: SurveyStatus;
     extended?: boolean;
-    size?: string;
+    size?: StatusTagSize;
+}
+
+export enum StatusTagSize {
+    Small = 'small',
+    Medium = 'medium',
+    Large = 'large',
 }
 
 export class StatusTag extends Component<StatusTagProps> {
     static defaultProps: Partial<StatusTagProps> = {
         extended: false,
-        size: 'medium',
+        size: StatusTagSize.Medium,
     };
 
     mapStatusToTooltip = (status: SurveyStatus): string => {
@@ -42,7 +48,7 @@ export class StatusTag extends Component<StatusTagProps> {
         }
     };
 
-    mapSizeToStyle = (size: string): CSSProperties => {
+    mapSizeToStyle = (size: StatusTagSize): CSSProperties => {
         switch (size) {
             case 'small':
                 return { padding: '0px 6px 10px', fontSize: 10 };

--- a/src/common/components/status-tag/status-tag.component.tsx
+++ b/src/common/components/status-tag/status-tag.component.tsx
@@ -1,13 +1,20 @@
 import { Icon, Tag, Tooltip } from 'antd';
-import React, { Component } from 'react';
+import React, { Component, CSSProperties } from 'react';
 import { mapStatusToColor } from '../../mappers/survey-status.mapper';
 import { SurveyStatus } from '../../types/survey-status.type';
 
 export interface StatusTagProps {
     status: SurveyStatus;
+    extended?: boolean;
+    size?: string;
 }
 
 export class StatusTag extends Component<StatusTagProps> {
+    static defaultProps: Partial<StatusTagProps> = {
+        extended: false,
+        size: 'medium',
+    };
+
     mapStatusToTooltip = (status: SurveyStatus): string => {
         switch (status) {
             case SurveyStatus.Published:
@@ -35,8 +42,20 @@ export class StatusTag extends Component<StatusTagProps> {
         }
     };
 
+    mapSizeToStyle = (size: string): CSSProperties => {
+        switch (size) {
+            case 'small':
+                return { padding: '0px 6px 10px', fontSize: 10 };
+            case 'large':
+                return { padding: '6px 9px 24px', fontSize: 15 };
+            default:
+            case 'medium':
+                return { padding: '3px 7px 22px', fontSize: 13 };
+        }
+    };
+
     render() {
-        const { status } = this.props;
+        const { status, size, extended } = this.props;
 
         const color = mapStatusToColor(status);
         const tooltip = this.mapStatusToTooltip(status);
@@ -44,8 +63,9 @@ export class StatusTag extends Component<StatusTagProps> {
 
         return (
             <Tooltip placement="top" title={tooltip}>
-                <Tag color={color}>
+                <Tag style={this.mapSizeToStyle(size!)} color={color}>
                     <Icon type={icon} />
+                    {extended ? <span style={{ paddingLeft: '5px' }}>{status}</span> : null}
                 </Tag>
             </Tooltip>
         );

--- a/src/common/components/status-tag/status-tag.component.tsx
+++ b/src/common/components/status-tag/status-tag.component.tsx
@@ -3,22 +3,19 @@ import React, { Component, CSSProperties } from 'react';
 import { mapStatusToColor } from '../../mappers/survey-status.mapper';
 import { SurveyStatus } from '../../types/survey-status.type';
 
+declare const StatusTagSizes: ['small', 'medium', 'large'];
+export declare type StatusTagSize = (typeof StatusTagSizes)[number];
+
 export interface StatusTagProps {
     status: SurveyStatus;
     extended?: boolean;
     size?: StatusTagSize;
 }
 
-export enum StatusTagSize {
-    Small = 'small',
-    Medium = 'medium',
-    Large = 'large',
-}
-
 export class StatusTag extends Component<StatusTagProps> {
     static defaultProps: Partial<StatusTagProps> = {
         extended: false,
-        size: StatusTagSize.Medium,
+        size: 'medium',
     };
 
     mapStatusToTooltip = (status: SurveyStatus): string => {

--- a/src/common/types/survey-status.type.ts
+++ b/src/common/types/survey-status.type.ts
@@ -1,6 +1,6 @@
 export enum SurveyStatus {
-    Published = 'published',
-    InProgress = 'inprogress',
-    Cancelled = 'cancelled',
-    Warning = 'warning',
+    Published = 'Published',
+    InProgress = 'In Progress',
+    Cancelled = 'Cancelled',
+    Warning = 'Warning',
 }

--- a/src/state/state.constants.ts
+++ b/src/state/state.constants.ts
@@ -1,6 +1,7 @@
 import { DeepPartial } from 'redux';
 import uuid from 'uuid/v4';
 import { Environment } from '../common/types/environment.type';
+import { SurveyStatus } from '../common/types/survey-status.type';
 import { AppState } from './index';
 
 // Define a preloadedState for createStore()
@@ -16,7 +17,7 @@ export const DEFAULT_STATE: { [key in Environment]: DeepPartial<AppState> } = {
                     createdAt: 1542225329,
                     modifiedAt: 1549233329,
                     questionCount: 11,
-                    status: 'published',
+                    status: SurveyStatus.Published,
                 },
             ],
         },
@@ -30,7 +31,7 @@ export const DEFAULT_STATE: { [key in Environment]: DeepPartial<AppState> } = {
                     createdAt: 1542225329,
                     modifiedAt: 1549233329,
                     questionCount: 11,
-                    status: 'published',
+                    status: SurveyStatus.Published,
                 },
                 {
                     key: uuid(), // https://www.npmjs.com/package/uuid
@@ -38,7 +39,7 @@ export const DEFAULT_STATE: { [key in Environment]: DeepPartial<AppState> } = {
                     createdAt: 1549238929,
                     modifiedAt: 1549325329,
                     questionCount: 7,
-                    status: 'warning',
+                    status: SurveyStatus.Warning,
                 },
                 {
                     key: uuid(),
@@ -46,7 +47,7 @@ export const DEFAULT_STATE: { [key in Environment]: DeepPartial<AppState> } = {
                     createdAt: 1547049812,
                     modifiedAt: 1547827412,
                     questionCount: 3,
-                    status: 'inprogress',
+                    status: SurveyStatus.InProgress,
                 },
                 {
                     key: uuid(),
@@ -54,7 +55,7 @@ export const DEFAULT_STATE: { [key in Environment]: DeepPartial<AppState> } = {
                     createdAt: 1511049812,
                     modifiedAt: 1522827412,
                     questionCount: 5,
-                    status: 'cancelled',
+                    status: SurveyStatus.Cancelled,
                 },
             ],
         },


### PR DESCRIPTION
<img width="561" alt="image" src="https://user-images.githubusercontent.com/15365152/52523448-e677c600-2c91-11e9-8861-ccb336f02192.png">

Note: This example is outdated. The large variations have 2px less paddingTop now.

Usage example: 
```jsx
<StatusTag status={SurveyStatus.Published} size="small" extended />
<StatusTag status={SurveyStatus.InProgress} size="medium" />
<StatusTag status={SurveyStatus.Warning} size="large" extended />
```